### PR TITLE
29510 #NA #NC #SO

### DIFF
--- a/Node/BinaryNode.php
+++ b/Node/BinaryNode.php
@@ -122,26 +122,90 @@ class BinaryNode extends Node
             case '!==':
                 return $left !== $right;
             case '<':
+                if ('#NC' === $left || '#NC' === $right) {
+                    return false;
+                } elseif ('#NA' === $left || '#NA' === $right) {
+                    return false;
+                } elseif ('#SO' === $left || '#SO' === $right) {
+                    return false;
+                }
+
                 return $left < $right && is_numeric($left) && is_numeric($right);
             case '>':
+                if ('#NC' === $left || '#NC' === $right) {
+                    return false;
+                } elseif ('#NA' === $left || '#NA' === $right) {
+                    return false;
+                } elseif ('#SO' === $left || '#SO' === $right) {
+                    return false;
+                }
+
                 return $left > $right && is_numeric($left) && is_numeric($right);
             case '>=':
+                if ('#NC' === $left || '#NC' === $right) {
+                    return false;
+                } elseif ('#NA' === $left || '#NA' === $right) {
+                    return false;
+                } elseif ('#SO' === $left || '#SO' === $right) {
+                    return false;
+                }
+
                 return $left >= $right && is_numeric($left) && is_numeric($right);
             case '<=':
+                if ('#NC' === $left || '#NC' === $right) {
+                    return false;
+                } elseif ('#NA' === $left || '#NA' === $right) {
+                    return false;
+                } elseif ('#SO' === $left || '#SO' === $right) {
+                    return false;
+                }
+
                 return $left <= $right && is_numeric($left) && is_numeric($right);
             case 'not in':
                 return !in_array($left, $right);
             case 'in':
                 return in_array($left, $right);
             case '+':
+                if ('#NC' === $left || '#NC' === $right) {
+                    return '#NC';
+                } elseif ('#NA' === $left || '#NA' === $right) {
+                    return '#NA';
+                } elseif ('#SO' === $left || '#SO' === $right) {
+                    return '#SO';
+                }
+
                 return $left + $right;
             case '-':
+                if ('#NC' === $left || '#NC' === $right) {
+                    return '#NC';
+                } elseif ('#NA' === $left || '#NA' === $right) {
+                    return '#NA';
+                } elseif ('#SO' === $left || '#SO' === $right) {
+                    return '#SO';
+                }
+
                 return $left - $right;
             case '~':
                 return $left.$right;
             case '*':
+                if ('#NC' === $left || '#NC' === $right) {
+                    return '#NC';
+                } elseif ('#NA' === $left || '#NA' === $right) {
+                    return '#NA';
+                } elseif ('#SO' === $left || '#SO' === $right) {
+                    return '#SO';
+                }
+
                 return $left * $right;
             case '/':
+                if ('#NC' === $left || '#NC' === $right) {
+                    return '#NC';
+                } elseif ('#NA' === $left || '#NA' === $right) {
+                    return '#NA';
+                } elseif ('#SO' === $left || '#SO' === $right) {
+                    return '#SO';
+                }
+
                 return $left / $right;
             case '%':
                 return $left % $right;


### PR DESCRIPTION
Ticket #29510

Pour éviter des warnings pour le passage à PHP 7.1+ (http://php.net/manual/fr/migration71.other-changes.php), il faut intégrer nos valeurs métiers #NA, #NC et #SO et les gérer lorsque l'on évalue les expressions.
Bien que ce soit techniquement un BC break, laisser l'auto casting de PHP était une régression par rapport à notre interpréteur de formules legacy, car celui-ci gérait les cas particuliers #NA, #NC et #SO.